### PR TITLE
Fix flow annotation in examples

### DIFF
--- a/examples/PasscodeAuthExample/Libraries/PasscodeAuth/PasscodeAuth.ios.js
+++ b/examples/PasscodeAuthExample/Libraries/PasscodeAuth/PasscodeAuth.ios.js
@@ -28,7 +28,7 @@ var Passcode = {
     });
   },
 
-  authenticate(reason) {
+  authenticate(reason: string) {
     var authReason;
 
     // Set auth reason


### PR DESCRIPTION
I caught this error in ci.

```bash
node_modules/react-native-passcode-auth/examples/PasscodeAuthExample/Libraries/PasscodeAuth/PasscodeAuth.ios.js:31
 31:   authenticate(reason) {
                    ^^^^^^ parameter `reason`. Missing annotation
```

Or remove `examples` to fix them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moqada/react-native-passcode-auth/1)
<!-- Reviewable:end -->
